### PR TITLE
Add name for service of fastapi

### DIFF
--- a/k8s/fastapi/base/service.yaml
+++ b/k8s/fastapi/base/service.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     app: fastapi
   ports:
-  - protocol: TCP
-    port: 8000
-    targetPort: 80
-
+    - protocol: TCP
+      name: api
+      port: 8000
+      targetPort: 80


### PR DESCRIPTION
# Why

To serve Prometheus metrics

# What

Add name
