### PR TITLE
Revert setting of pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-      # - id: check-added-large-files
+      - id: check-added-large-files
       - id: detect-aws-credentials
         args: [--allow-missing-credentials]
       - id: detect-private-key


### PR DESCRIPTION
# Why

To revert the change made in https://github.com/k3forx/fastapi-example/pull/52

# What

Enable `check-added-large-files` again
