### PR TITLE
Update service monitor config

### DIFF
--- a/k8s/prometheus-operator/service-monitor/fastapi.yaml
+++ b/k8s/prometheus-operator/service-monitor/fastapi.yaml
@@ -6,7 +6,8 @@ metadata:
     app: fastapi
 spec:
   namespaceSelector:
-    matchNames: api-app
+    matchNames:
+      - api-app
   selector:
     matchLabels:
       app: fastapi


### PR DESCRIPTION
# Why

To fix the following error
```bash
error: error validating "k8s/prometheus-operator/": error validating data: ValidationError(ServiceMonitor.spec.namespaceSelector.matchNames): invalid type for com.coreos.monitoring.v1.ServiceMonitor.spec.namespaceSelector.matchNames: got "string", expected "array"; if you choose to ignore these errors, turn validation off with --validate=false
```

# What

Change the config
