### PR TITLE
Increase the number of replicas

### DIFF
--- a/k8s/fastapi/overlays/api-app/deployment.yaml
+++ b/k8s/fastapi/overlays/api-app/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: fastapi
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: fastapi


### PR DESCRIPTION
# Why

To confirm that the service monitor can check the status of all the replicas

# What

Increase the number of replicas from `1` to `2`
