### PR TITLE
Enable to store note in Japanese

### DIFF
--- a/app/integration_test/test_api_endpoints.py
+++ b/app/integration_test/test_api_endpoints.py
@@ -42,7 +42,7 @@ def test_GET_note_by_id():
 def test_POST_note():
     payload = {
         "title": "Engineering Organization Theory",
-        "description": "Interasting book!",
+        "description": "興味深い本ですね",
     }
     expect_body = {"message": "The new note is created successfully"}
 

--- a/db/my.cnf
+++ b/db/my.cnf
@@ -1,0 +1,5 @@
+[mysqld]
+character-set-server=utf8mb4
+
+[client]
+default-character-set=utf8mb4

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,7 @@ services:
     volumes:
       - ./db/schema.sql:/docker-entrypoint-initdb.d/01_schema.sql
       - ./db/data.sql:/docker-entrypoint-initdb.d/02_data.sql
+      - ./db/my.cnf:/etc/mysql/conf.d/my.cnf
 
   fastapi:
     build: ./app


### PR DESCRIPTION
# Why

Can't store notes in Japanese

# What

- Add `my.cnf` for character setting
- Update test case
